### PR TITLE
Add build automation and self-update orchestration

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,557 @@
+package main
+
+// The main package wires together storage, billing, mail, auth, scheduler, builds, and updates.
+// We coordinate everything through goroutines and channels to follow the requested design rules.
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/example/chicha-care/internal/auth"
+	"github.com/example/chicha-care/internal/billing"
+	"github.com/example/chicha-care/internal/build"
+	"github.com/example/chicha-care/internal/mail"
+	"github.com/example/chicha-care/internal/scheduler"
+	"github.com/example/chicha-care/internal/storage"
+	"github.com/example/chicha-care/internal/update"
+	"github.com/example/chicha-care/internal/upgrade"
+)
+
+// version is injected at build time; we default to dev for local runs.
+var version = "dev"
+
+// main simply delegates to run so we can return rich errors.
+func main() {
+	if err := run(); err != nil {
+		log.Fatalf("run: %v", err)
+	}
+}
+
+// run prepares services, starts background workers, and holds the main loop.
+func run() error {
+	httpAddr := flag.String("http", ":80", "HTTP listen address")
+	httpsAddr := flag.String("https", ":443", "HTTPS listen address")
+	smtpAddr := flag.String("smtp", ":25", "SMTP listen address")
+	enableTLS := flag.Bool("enable-https", false, "Enable HTTPS listener")
+	domain := flag.String("domain", "chicha-care.local", "Domain for HTTPS certificate")
+	invoiceInterval := flag.Duration("invoice-interval", 30*24*time.Hour, "Invoice generation interval")
+	invoiceAmount := flag.Float64("invoice-amount", 37236, "Default invoice amount")
+	repoPath := flag.String("repo-path", ".", "Repository path for build automation")
+	buildInterval := flag.Duration("build-interval", time.Minute, "How often to check commits for Stable Release tags")
+	updateOwner := flag.String("update-owner", "example", "GitHub owner for update checks")
+	updateRepo := flag.String("update-repo", "chicha-care", "GitHub repository for update checks")
+	updateBinary := flag.String("update-binary", "chicha-care", "Binary name used by release assets")
+	updateInterval := flag.Duration("update-interval", time.Minute, "How often to poll for new releases")
+	flag.Parse()
+
+	controlPath := os.Getenv("CHICHA_UPGRADE_CONTROL")
+	var handshakeAcknowledged bool
+	if controlPath != "" {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+		if err := upgrade.WaitForGo(ctx, controlPath); err != nil {
+			upgrade.WriteState(controlPath, upgrade.StateAbort)
+			return fmt.Errorf("upgrade wait: %w", err)
+		}
+		defer func() {
+			if !handshakeAcknowledged {
+				upgrade.WriteState(controlPath, upgrade.StateAbort)
+			}
+		}()
+	}
+
+	storage.Register()
+	db, err := sql.Open("inmemory", "primary")
+	if err != nil {
+		return fmt.Errorf("open db: %w", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+
+	authSvc := auth.NewService(db)
+	if err := authSvc.EnsureSchema(ctx); err != nil {
+		return fmt.Errorf("auth schema: %w", err)
+	}
+	if err := authSvc.Register(ctx, "admin", "admin"); err != nil {
+		log.Printf("auth register: %v", err)
+	}
+
+	mailSvc := mail.NewService(32)
+	if err := mailSvc.StartSMTPServer(*smtpAddr); err != nil {
+		return fmt.Errorf("smtp server: %w", err)
+	}
+	defer mailSvc.StopSMTPServer()
+
+	signer, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return fmt.Errorf("rsa key: %w", err)
+	}
+
+	billingSvc := billing.NewService(db, signer, mailSvc.Deliveries())
+	if err := billingSvc.EnsureSchema(ctx); err != nil {
+		return fmt.Errorf("billing schema: %w", err)
+	}
+
+	sched := scheduler.New(billingSvc, *invoiceInterval, *invoiceAmount)
+	sched.Start()
+	defer sched.Stop()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", homeHandler)
+	mux.Handle("/clients", authSvc.Middleware(http.HandlerFunc(clientsHandler(billingSvc))))
+	mux.Handle("/invoices", authSvc.Middleware(http.HandlerFunc(invoicesHandler(billingSvc))))
+
+	buildSvc := build.NewService(build.Config{RepoPath: *repoPath, Binary: *updateBinary, Interval: *buildInterval})
+	buildSvc.Start()
+	defer buildSvc.Stop()
+	go monitorBuilds(buildSvc.Events())
+
+	updateSvc := update.NewService(update.Config{
+		Owner:          *updateOwner,
+		Repo:           *updateRepo,
+		Binary:         *updateBinary,
+		Interval:       *updateInterval,
+		CurrentVersion: version,
+	})
+	updateSvc.Start()
+	defer updateSvc.Stop()
+	updates := updateSvc.Events()
+
+	cfg := serverConfig{
+		HTTPAddr:  *httpAddr,
+		HTTPSAddr: *httpsAddr,
+		EnableTLS: *enableTLS,
+		Domain:    *domain,
+		Handler:   mux,
+	}
+
+	server, tlsServer, errChan, err := startServers(cfg)
+	if err != nil {
+		return fmt.Errorf("start servers: %w", err)
+	}
+	if controlPath != "" {
+		if err := upgrade.WriteState(controlPath, upgrade.StateRunning); err != nil {
+			return fmt.Errorf("signal running: %w", err)
+		}
+		handshakeAcknowledged = true
+	}
+
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, os.Interrupt, syscall.SIGTERM)
+
+	for {
+		select {
+		case sig := <-sigs:
+			log.Printf("received signal %v, shutting down", sig)
+			shutdownHTTPServers(server, tlsServer)
+			return nil
+		case err := <-errChan:
+			if err == nil || errors.Is(err, http.ErrServerClosed) {
+				continue
+			}
+			return fmt.Errorf("server error: %w", err)
+		case evt, ok := <-updates:
+			if !ok {
+				updates = nil
+				continue
+			}
+			success, restart, uErr := handleUpdate(evt, errChan, server, tlsServer, mailSvc)
+			if uErr != nil {
+				log.Printf("update: %v", uErr)
+			}
+			if success {
+				return nil
+			}
+			if restart {
+				if err := mailSvc.StartSMTPServer(*smtpAddr); err != nil {
+					return fmt.Errorf("restart smtp: %w", err)
+				}
+				server, tlsServer, errChan, err = startServers(cfg)
+				if err != nil {
+					return fmt.Errorf("restart http: %w", err)
+				}
+			}
+		}
+	}
+}
+
+// serverConfig groups the knobs required to run HTTP and HTTPS listeners.
+type serverConfig struct {
+	HTTPAddr  string
+	HTTPSAddr string
+	EnableTLS bool
+	Domain    string
+	Handler   http.Handler
+}
+
+// startServers binds the listeners before spinning goroutines so we know they succeed.
+func startServers(cfg serverConfig) (*http.Server, *http.Server, chan error, error) {
+	errChan := make(chan error, 2)
+	lnHTTP, err := net.Listen("tcp", cfg.HTTPAddr)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	server := &http.Server{Addr: cfg.HTTPAddr, Handler: cfg.Handler}
+
+	var lnHTTPS net.Listener
+	var tlsServer *http.Server
+	if cfg.EnableTLS {
+		cert, err := generateCertificate(cfg.Domain)
+		if err != nil {
+			lnHTTP.Close()
+			return nil, nil, nil, err
+		}
+		lnHTTPS, err = net.Listen("tcp", cfg.HTTPSAddr)
+		if err != nil {
+			lnHTTP.Close()
+			return nil, nil, nil, err
+		}
+		tlsServer = &http.Server{Addr: cfg.HTTPSAddr, Handler: cfg.Handler, TLSConfig: &tls.Config{Certificates: []tls.Certificate{cert}}}
+	}
+
+	go func() {
+		log.Printf("HTTP listening on %s", cfg.HTTPAddr)
+		errChan <- server.Serve(lnHTTP)
+	}()
+
+	if tlsServer != nil {
+		go func() {
+			log.Printf("HTTPS listening on %s", cfg.HTTPSAddr)
+			errChan <- tlsServer.Serve(tls.NewListener(lnHTTPS, tlsServer.TLSConfig))
+		}()
+	}
+
+	return server, tlsServer, errChan, nil
+}
+
+// shutdownHTTPServers gracefully stops both HTTP and HTTPS listeners.
+func shutdownHTTPServers(server, tlsServer *http.Server) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if server != nil {
+		if err := server.Shutdown(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Printf("http shutdown: %v", err)
+		}
+	}
+	if tlsServer != nil {
+		if err := tlsServer.Shutdown(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Printf("https shutdown: %v", err)
+		}
+	}
+}
+
+// shutdownHTTPServersForUpdate wraps shutdownHTTPServers so we can bubble errors up during upgrades.
+func shutdownHTTPServersForUpdate(server, tlsServer *http.Server) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var errs []error
+	if server != nil {
+		if err := server.Shutdown(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errs = append(errs, fmt.Errorf("http shutdown: %w", err))
+		}
+	}
+	if tlsServer != nil {
+		if err := tlsServer.Shutdown(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errs = append(errs, fmt.Errorf("https shutdown: %w", err))
+		}
+	}
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}
+
+// handleUpdate orchestrates the handover to a freshly downloaded binary.
+func handleUpdate(evt update.Event, errChan chan error, server *http.Server, tlsServer *http.Server, mailSvc *mail.Service) (bool, bool, error) {
+	if evt.BinaryPath == "" {
+		return false, false, errors.New("update event missing binary path")
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return false, false, err
+	}
+	dir := filepath.Dir(exe)
+	handshakePath := filepath.Join(dir, fmt.Sprintf(".upgrade-%d", time.Now().UnixNano()))
+	if err := upgrade.WriteState(handshakePath, upgrade.StatePending); err != nil {
+		return false, false, err
+	}
+	defer os.Remove(handshakePath)
+
+	cmd := exec.Command(evt.BinaryPath, os.Args[1:]...)
+	cmd.Env = append(os.Environ(),
+		"CHICHA_UPGRADE_CONTROL="+handshakePath,
+		"CHICHA_UPGRADE_PREVIOUS="+exe,
+		"CHICHA_UPGRADE_VERSION="+evt.Version,
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Start(); err != nil {
+		return false, false, err
+	}
+
+	exitChan := make(chan error, 1)
+	go func() {
+		exitChan <- cmd.Wait()
+	}()
+
+	standbyCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	standby := make(chan error, 1)
+	go func() {
+		_, err := upgrade.WaitForState(standbyCtx, handshakePath, upgrade.StateStandby)
+		standby <- err
+	}()
+
+	select {
+	case err := <-standby:
+		if err != nil {
+			upgrade.WriteState(handshakePath, upgrade.StateAbort)
+			waitProcessExit(exitChan, cmd)
+			return false, false, err
+		}
+	case err := <-exitChan:
+		upgrade.WriteState(handshakePath, upgrade.StateAbort)
+		return false, false, fmt.Errorf("new version exited before standby: %w", err)
+	}
+
+	mailSvc.StopSMTPServer()
+
+	if err := shutdownHTTPServersForUpdate(server, tlsServer); err != nil {
+		upgrade.WriteState(handshakePath, upgrade.StateAbort)
+		waitProcessExit(exitChan, cmd)
+		return false, true, err
+	}
+	drainErrChan(errChan)
+
+	if err := upgrade.WriteState(handshakePath, upgrade.StateGo); err != nil {
+		waitProcessExit(exitChan, cmd)
+		return false, true, err
+	}
+
+	runCtx, cancelRun := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancelRun()
+	stateCh := make(chan struct {
+		state string
+		err   error
+	}, 1)
+	go func() {
+		state, err := upgrade.WaitForState(runCtx, handshakePath, upgrade.StateRunning, upgrade.StateAbort)
+		stateCh <- struct {
+			state string
+			err   error
+		}{state: state, err: err}
+	}()
+
+	select {
+	case res := <-stateCh:
+		if res.err != nil {
+			upgrade.WriteState(handshakePath, upgrade.StateAbort)
+			waitProcessExit(exitChan, cmd)
+			return false, true, res.err
+		}
+		if res.state == upgrade.StateRunning {
+			return true, false, nil
+		}
+		upgrade.WriteState(handshakePath, upgrade.StateAbort)
+		waitProcessExit(exitChan, cmd)
+		return false, true, fmt.Errorf("new version reported abort")
+	case err := <-exitChan:
+		upgrade.WriteState(handshakePath, upgrade.StateAbort)
+		return false, true, fmt.Errorf("new version exited during startup: %w", err)
+	}
+}
+
+// waitProcessExit tries to reap the child process so we do not leak zombies.
+func waitProcessExit(exit <-chan error, cmd *exec.Cmd) {
+	select {
+	case <-exit:
+	case <-time.After(2 * time.Second):
+		if cmd.Process != nil {
+			cmd.Process.Kill()
+		}
+	}
+}
+
+// drainErrChan removes stale shutdown events so restarts get a clean channel.
+func drainErrChan(ch chan error) {
+	for {
+		select {
+		case <-ch:
+		default:
+			return
+		}
+	}
+}
+
+// monitorBuilds logs build events so operators can trace automation decisions.
+func monitorBuilds(events <-chan build.Event) {
+	for evt := range events {
+		if evt.Err != nil {
+			log.Printf("build trigger failed: %v", evt.Err)
+			continue
+		}
+		log.Printf("build triggered for %s: %s", evt.Commit, evt.Message)
+		for _, res := range evt.Results {
+			if res.Err != nil {
+				log.Printf("build %s/%s failed: %v", res.Target.GOOS, res.Target.GOARCH, res.Err)
+			} else {
+				log.Printf("build %s/%s artifact at %s", res.Target.GOOS, res.Target.GOARCH, res.Artifact)
+			}
+		}
+	}
+}
+
+// homeHandler prints a quick status with helpful instructions.
+func homeHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	fmt.Fprintln(w, "Chicha Care billing system is running. Use authenticated endpoints to manage clients and invoices.")
+}
+
+// clientsHandler provides GET and POST handling using JSON payloads.
+func clientsHandler(bill *billing.Service) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+			defer cancel()
+			clients, err := bill.ListClients(ctx)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			respondJSON(w, clients)
+		case http.MethodPost:
+			defer r.Body.Close()
+			var payload struct {
+				ID    string `json:"id"`
+				Name  string `json:"name"`
+				Email string `json:"email"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+			defer cancel()
+			if err := bill.AddClient(ctx, billing.Client{ID: payload.ID, Name: payload.Name, Email: payload.Email}); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			w.WriteHeader(http.StatusCreated)
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	}
+}
+
+// invoicesHandler handles listing and manual invoice creation.
+func invoicesHandler(bill *billing.Service) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			clientID := r.URL.Query().Get("client")
+			ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+			defer cancel()
+			invoices, err := bill.ListInvoices(ctx, clientID)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			respondJSON(w, mapInvoices(invoices))
+		case http.MethodPost:
+			defer r.Body.Close()
+			var payload struct {
+				ClientID string  `json:"client_id"`
+				Amount   float64 `json:"amount"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+			defer cancel()
+			invoice, err := bill.CreateInvoice(ctx, payload.ClientID, payload.Amount)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			respondJSON(w, invoiceDTO(invoice))
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	}
+}
+
+// respondJSON writes the provided value as JSON.
+func respondJSON(w http.ResponseWriter, v interface{}) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// mapInvoices converts invoices to DTOs that expose base64 encoded fields.
+func mapInvoices(invoices []billing.Invoice) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(invoices))
+	for _, inv := range invoices {
+		result = append(result, invoiceDTO(inv))
+	}
+	return result
+}
+
+// invoiceDTO serializes the invoice document and signature in a friendly format.
+func invoiceDTO(inv billing.Invoice) map[string]interface{} {
+	return map[string]interface{}{
+		"id":        inv.ID,
+		"client_id": inv.ClientID,
+		"amount":    inv.Amount,
+		"issued_at": inv.IssuedAt.Format(time.RFC3339Nano),
+		"document":  base64.StdEncoding.EncodeToString(inv.Document),
+		"signature": base64.StdEncoding.EncodeToString(inv.Signature),
+	}
+}
+
+// generateCertificate builds a self-signed certificate for the provided domain.
+func generateCertificate(domain string) (tls.Certificate, error) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(365 * 24 * time.Hour),
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{domain},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	return tls.X509KeyPair(certPEM, keyPEM)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/example/chicha-care
+
+go 1.24.3

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -1,0 +1,183 @@
+package auth
+
+// The auth package wraps access to the user table with a channel-based service.
+// We keep all logic asynchronous so other components do not block each other.
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"database/sql"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+// Service exposes user registration and authentication helpers through channels.
+type Service struct {
+	db        *sql.DB
+	requests  chan interface{}
+	responses chan interface{}
+}
+
+// NewService prepares the service loop and ensures the user table exists.
+func NewService(db *sql.DB) *Service {
+	svc := &Service{
+		db:        db,
+		requests:  make(chan interface{}),
+		responses: make(chan interface{}),
+	}
+	go svc.loop()
+	return svc
+}
+
+// loop processes one request at a time and uses the database/sql API.
+func (s *Service) loop() {
+	for {
+		select {
+		case req := <-s.requests:
+			switch msg := req.(type) {
+			case registerRequest:
+				s.responses <- s.handleRegister(msg)
+			case authRequest:
+				s.responses <- s.handleAuth(msg)
+			default:
+				s.responses <- fmt.Errorf("unknown request %T", msg)
+			}
+		}
+	}
+}
+
+type registerRequest struct {
+	Username string
+	Password string
+}
+
+type authRequest struct {
+	Username string
+	Password string
+}
+
+// EnsureSchema prepares the tables we use for credentials management.
+func (s *Service) EnsureSchema(ctx context.Context) error {
+	_, err := s.db.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS users(username TEXT PRIMARY KEY, hash TEXT)`)
+	return err
+}
+
+// Register stores a new user with a salted hash.
+func (s *Service) Register(ctx context.Context, username, password string) error {
+	select {
+	case s.requests <- registerRequest{Username: username, Password: password}:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	resp := <-s.responses
+	if err, ok := resp.(error); ok {
+		return err
+	}
+	return nil
+}
+
+func (s *Service) handleRegister(req registerRequest) error {
+	rows, err := s.db.Query(`SELECT username FROM users WHERE username = ?`, req.Username)
+	if err == nil {
+		defer rows.Close()
+		if rows.Next() {
+			return fmt.Errorf("user %s already exists", req.Username)
+		}
+	}
+	hashed, err := hashPassword(req.Password)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.Exec(`INSERT INTO users(username,hash) VALUES(?,?)`, req.Username, hashed)
+	return err
+}
+
+// Authenticate validates a username/password pair using constant-time comparison.
+func (s *Service) Authenticate(ctx context.Context, username, password string) (bool, error) {
+	select {
+	case s.requests <- authRequest{Username: username, Password: password}:
+	case <-ctx.Done():
+		return false, ctx.Err()
+	}
+	resp := <-s.responses
+	switch val := resp.(type) {
+	case authResult:
+		return val.OK, val.Err
+	case error:
+		return false, val
+	default:
+		return false, fmt.Errorf("unexpected response %T", resp)
+	}
+}
+
+type authResult struct {
+	OK  bool
+	Err error
+}
+
+func (s *Service) handleAuth(req authRequest) authResult {
+	row, err := s.db.Query(`SELECT username,hash FROM users WHERE username = ?`, req.Username)
+	if err != nil {
+		return authResult{OK: false, Err: err}
+	}
+	defer row.Close()
+	if !row.Next() {
+		return authResult{OK: false, Err: errors.New("unknown user")}
+	}
+	var username, hash string
+	if err := row.Scan(&username, &hash); err != nil {
+		return authResult{OK: false, Err: err}
+	}
+	if verifyPassword(hash, req.Password) {
+		return authResult{OK: true, Err: nil}
+	}
+	return authResult{OK: false, Err: errors.New("invalid credentials")}
+}
+
+// Middleware wraps handlers with HTTP Basic authentication.
+func (s *Service) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		username, password, ok := r.BasicAuth()
+		if !ok {
+			w.Header().Set("WWW-Authenticate", "Basic realm=restricted")
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		ok, err := s.Authenticate(r.Context(), username, password)
+		if err != nil || !ok {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// hashPassword salts and hashes passwords to keep secrets safe.
+func hashPassword(password string) (string, error) {
+	salt := make([]byte, 16)
+	if _, err := rand.Read(salt); err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(append(salt, []byte(password)...))
+	blob := append(salt, sum[:]...)
+	return base64.StdEncoding.EncodeToString(blob), nil
+}
+
+// verifyPassword checks a password using constant-time comparison.
+func verifyPassword(encoded, password string) bool {
+	raw, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil || len(raw) <= 16 {
+		return false
+	}
+	salt := raw[:16]
+	stored := raw[16:]
+	sum := sha256.Sum256(append(salt, []byte(password)...))
+	if len(stored) != len(sum) {
+		return false
+	}
+	return subtle.ConstantTimeCompare(stored, sum[:]) == 1
+}

--- a/internal/billing/service.go
+++ b/internal/billing/service.go
@@ -1,0 +1,324 @@
+package billing
+
+// The billing package manages clients and invoices through an asynchronous
+// service. We keep logic small and composable so it can work well with channels.
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/example/chicha-care/internal/mail"
+)
+
+// Client represents an entity that receives invoices.
+type Client struct {
+	ID    string
+	Name  string
+	Email string
+}
+
+// Invoice stores the rendered invoice and its digital signature.
+type Invoice struct {
+	ID        string
+	ClientID  string
+	Amount    float64
+	IssuedAt  time.Time
+	Document  []byte
+	Signature []byte
+}
+
+// Service coordinates DB access and document signing.
+type Service struct {
+	db        *sql.DB
+	signer    *rsa.PrivateKey
+	mailOut   chan<- mail.Message
+	requests  chan interface{}
+	responses chan interface{}
+}
+
+// NewService spins the event loop that serializes DB operations.
+func NewService(db *sql.DB, signer *rsa.PrivateKey, mailOut chan<- mail.Message) *Service {
+	svc := &Service{
+		db:        db,
+		signer:    signer,
+		mailOut:   mailOut,
+		requests:  make(chan interface{}),
+		responses: make(chan interface{}),
+	}
+	go svc.loop()
+	return svc
+}
+
+// loop keeps DB usage sequential so we can avoid mutexes.
+func (s *Service) loop() {
+	for {
+		select {
+		case req := <-s.requests:
+			switch msg := req.(type) {
+			case addClientRequest:
+				s.responses <- s.handleAddClient(msg)
+			case listClientsRequest:
+				s.responses <- s.handleListClients()
+			case createInvoiceRequest:
+				s.responses <- s.handleCreateInvoice(msg)
+			case listInvoicesRequest:
+				s.responses <- s.handleListInvoices(msg)
+			default:
+				s.responses <- fmt.Errorf("unknown request %T", msg)
+			}
+		}
+	}
+}
+
+type addClientRequest struct {
+	Client Client
+}
+
+type listClientsRequest struct{}
+
+type createInvoiceRequest struct {
+	ClientID string
+	Amount   float64
+}
+
+type listInvoicesRequest struct {
+	ClientID string
+}
+
+// EnsureSchema creates the tables needed for billing.
+func (s *Service) EnsureSchema(ctx context.Context) error {
+	if _, err := s.db.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS clients(id TEXT PRIMARY KEY, name TEXT, email TEXT)`); err != nil {
+		return err
+	}
+	_, err := s.db.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS invoices(id TEXT PRIMARY KEY, client_id TEXT, amount REAL, issued_at TEXT, document BLOB, signature BLOB)`)
+	return err
+}
+
+// AddClient registers a new client.
+func (s *Service) AddClient(ctx context.Context, client Client) error {
+	select {
+	case s.requests <- addClientRequest{Client: client}:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	resp := <-s.responses
+	if err, ok := resp.(error); ok {
+		return err
+	}
+	return nil
+}
+
+func (s *Service) handleAddClient(req addClientRequest) error {
+	_, err := s.db.Exec(`INSERT INTO clients(id,name,email) VALUES(?,?,?)`, req.Client.ID, req.Client.Name, req.Client.Email)
+	return err
+}
+
+// ListClients returns all clients.
+func (s *Service) ListClients(ctx context.Context) ([]Client, error) {
+	select {
+	case s.requests <- listClientsRequest{}:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	resp := <-s.responses
+	switch val := resp.(type) {
+	case []Client:
+		return val, nil
+	case error:
+		return nil, val
+	default:
+		return nil, fmt.Errorf("unexpected response %T", resp)
+	}
+}
+
+func (s *Service) handleListClients() interface{} {
+	rows, err := s.db.Query(`SELECT id,name,email FROM clients`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	clients := []Client{}
+	for rows.Next() {
+		var c Client
+		if err := rows.Scan(&c.ID, &c.Name, &c.Email); err != nil {
+			return err
+		}
+		clients = append(clients, c)
+	}
+	return clients
+}
+
+// CreateInvoice builds, signs and stores a new invoice.
+func (s *Service) CreateInvoice(ctx context.Context, clientID string, amount float64) (Invoice, error) {
+	select {
+	case s.requests <- createInvoiceRequest{ClientID: clientID, Amount: amount}:
+	case <-ctx.Done():
+		return Invoice{}, ctx.Err()
+	}
+	resp := <-s.responses
+	switch val := resp.(type) {
+	case Invoice:
+		return val, nil
+	case error:
+		return Invoice{}, val
+	default:
+		return Invoice{}, fmt.Errorf("unexpected response %T", resp)
+	}
+}
+
+func (s *Service) handleCreateInvoice(req createInvoiceRequest) interface{} {
+	client, err := s.findClient(req.ClientID)
+	if err != nil {
+		return err
+	}
+	inv, err := s.buildInvoice(client, req.Amount)
+	if err != nil {
+		return err
+	}
+	if err := s.storeInvoice(inv); err != nil {
+		return err
+	}
+	s.dispatchInvoice(client, inv)
+	return inv
+}
+
+// findClient returns a client by ID.
+func (s *Service) findClient(id string) (Client, error) {
+	rows, err := s.db.Query(`SELECT id,name,email FROM clients WHERE id = ?`, id)
+	if err != nil {
+		return Client{}, err
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		return Client{}, errors.New("client not found")
+	}
+	var c Client
+	if err := rows.Scan(&c.ID, &c.Name, &c.Email); err != nil {
+		return Client{}, err
+	}
+	return c, nil
+}
+
+// buildInvoice creates the document and signature.
+func (s *Service) buildInvoice(client Client, amount float64) (Invoice, error) {
+	id, err := randomID()
+	if err != nil {
+		return Invoice{}, err
+	}
+	issued := time.Now().UTC()
+	payload := map[string]interface{}{
+		"invoice_id":  id,
+		"client_id":   client.ID,
+		"client_name": client.Name,
+		"amount":      amount,
+		"issued_at":   issued.Format(time.RFC3339Nano),
+	}
+	blob, err := json.Marshal(payload)
+	if err != nil {
+		return Invoice{}, err
+	}
+	signature, err := signBlob(s.signer, blob)
+	if err != nil {
+		return Invoice{}, err
+	}
+	return Invoice{
+		ID:        id,
+		ClientID:  client.ID,
+		Amount:    amount,
+		IssuedAt:  issued,
+		Document:  blob,
+		Signature: signature,
+	}, nil
+}
+
+// storeInvoice writes the invoice to the database.
+func (s *Service) storeInvoice(inv Invoice) error {
+	_, err := s.db.Exec(`INSERT INTO invoices(id,client_id,amount,issued_at,document,signature) VALUES(?,?,?,?,?,?)`, inv.ID, inv.ClientID, inv.Amount, inv.IssuedAt.Format(time.RFC3339Nano), inv.Document, inv.Signature)
+	return err
+}
+
+// dispatchInvoice notifies the mail subsystem.
+func (s *Service) dispatchInvoice(client Client, inv Invoice) {
+	msg := mail.Message{
+		From:    "billing@chicha-care.local",
+		To:      client.Email,
+		Subject: fmt.Sprintf("Invoice %s", inv.ID),
+		Body:    fmt.Sprintf("Attached invoice: %s\nSignature: %s", string(inv.Document), base64.StdEncoding.EncodeToString(inv.Signature)),
+	}
+	select {
+	case s.mailOut <- msg:
+	default:
+		// If the channel is full we drop the message to avoid blocking the scheduler.
+	}
+}
+
+// ListInvoices returns invoices optionally filtered by client.
+func (s *Service) ListInvoices(ctx context.Context, clientID string) ([]Invoice, error) {
+	select {
+	case s.requests <- listInvoicesRequest{ClientID: clientID}:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	resp := <-s.responses
+	switch val := resp.(type) {
+	case []Invoice:
+		return val, nil
+	case error:
+		return nil, val
+	default:
+		return nil, fmt.Errorf("unexpected response %T", resp)
+	}
+}
+
+func (s *Service) handleListInvoices(req listInvoicesRequest) interface{} {
+	query := `SELECT id,client_id,amount,issued_at,document,signature FROM invoices`
+	args := []interface{}{}
+	if req.ClientID != "" {
+		query += ` WHERE client_id = ?`
+		args = append(args, req.ClientID)
+	}
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	result := []Invoice{}
+	for rows.Next() {
+		var inv Invoice
+		var issued string
+		if err := rows.Scan(&inv.ID, &inv.ClientID, &inv.Amount, &issued, &inv.Document, &inv.Signature); err != nil {
+			return err
+		}
+		t, err := time.Parse(time.RFC3339Nano, issued)
+		if err != nil {
+			return err
+		}
+		inv.IssuedAt = t
+		result = append(result, inv)
+	}
+	return result
+}
+
+// randomID builds a unique identifier from crypto/rand.
+func randomID() (string, error) {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+// signBlob creates an RSA signature for the invoice payload.
+func signBlob(key *rsa.PrivateKey, blob []byte) ([]byte, error) {
+	hash := sha256.Sum256(blob)
+	return rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, hash[:])
+}

--- a/internal/build/service.go
+++ b/internal/build/service.go
@@ -1,0 +1,200 @@
+package build
+
+// Package build monitors git history and produces cross-platform binaries.
+// We coordinate everything with goroutines, channels, and select statements.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Target describes a GOOS/GOARCH pair we compile for.
+type Target struct {
+	GOOS   string
+	GOARCH string
+}
+
+// Result reports the outcome of a single build invocation.
+type Result struct {
+	Target   Target
+	Artifact string
+	Err      error
+}
+
+// Event bundles all results associated with a triggering commit.
+type Event struct {
+	Commit  string
+	Message string
+	Results []Result
+	Err     error
+}
+
+// Config carries the knobs for the Service so callers can customise it.
+type Config struct {
+	RepoPath  string
+	Binary    string
+	OutputDir string
+	Targets   []Target
+	Interval  time.Duration
+}
+
+// DefaultTargets mirrors the Chicha Isotope Map support matrix as a baseline.
+func DefaultTargets() []Target {
+	return []Target{
+		{GOOS: "linux", GOARCH: "amd64"},
+		{GOOS: "linux", GOARCH: "arm64"},
+		{GOOS: "darwin", GOARCH: "amd64"},
+		{GOOS: "darwin", GOARCH: "arm64"},
+		{GOOS: "windows", GOARCH: "amd64"},
+	}
+}
+
+// Service owns the polling ticker and build execution pipeline.
+type Service struct {
+	repoPath string
+	binary   string
+	output   string
+	targets  []Target
+	interval time.Duration
+
+	events chan Event
+	stop   chan struct{}
+	done   chan struct{}
+
+	lastCommit string
+}
+
+// NewService wires a new Service with sane defaults.
+func NewService(cfg Config) *Service {
+	if cfg.OutputDir == "" {
+		cfg.OutputDir = "dist"
+	}
+	if cfg.Interval == 0 {
+		cfg.Interval = time.Minute
+	}
+	if len(cfg.Targets) == 0 {
+		cfg.Targets = DefaultTargets()
+	}
+	if cfg.Binary == "" {
+		cfg.Binary = "chicha-care"
+	}
+	return &Service{
+		repoPath: cfg.RepoPath,
+		binary:   cfg.Binary,
+		output:   cfg.OutputDir,
+		targets:  append([]Target(nil), cfg.Targets...),
+		interval: cfg.Interval,
+		events:   make(chan Event, 1),
+		stop:     make(chan struct{}),
+		done:     make(chan struct{}),
+	}
+}
+
+// Events exposes the channel where build events are published.
+func (s *Service) Events() <-chan Event {
+	return s.events
+}
+
+// Start launches the monitoring loop.
+func (s *Service) Start() {
+	go s.loop()
+}
+
+// Stop terminates the monitoring loop and closes the events channel.
+func (s *Service) Stop() {
+	close(s.stop)
+	<-s.done
+}
+
+// loop polls git at the configured interval and kicks builds when needed.
+func (s *Service) loop() {
+	defer close(s.done)
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+	s.runOnce()
+	for {
+		select {
+		case <-ticker.C:
+			s.runOnce()
+		case <-s.stop:
+			close(s.events)
+			return
+		}
+	}
+}
+
+// runOnce checks the most recent commit message for the magic phrase.
+func (s *Service) runOnce() {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	commit, message, err := s.latestStable(ctx)
+	if err != nil {
+		s.events <- Event{Err: err}
+		return
+	}
+	if commit == "" || commit == s.lastCommit {
+		return
+	}
+	results := s.buildAll(ctx, commit)
+	s.lastCommit = commit
+	s.events <- Event{Commit: commit, Message: message, Results: results}
+}
+
+// latestStable returns the newest commit containing the Stable Release marker.
+func (s *Service) latestStable(ctx context.Context) (string, string, error) {
+	if s.repoPath == "" {
+		return "", "", errors.New("repository path not configured")
+	}
+	cmd := exec.CommandContext(ctx, "git", "-C", s.repoPath, "log", "--grep", "Stable Release", "-1", "--pretty=%H%x1f%s")
+	out, err := cmd.Output()
+	if err != nil {
+		// If git exits with status 128 because repo missing, surface the error.
+		return "", "", err
+	}
+	trimmed := strings.TrimSpace(string(out))
+	if trimmed == "" {
+		return "", "", nil
+	}
+	parts := strings.SplitN(trimmed, "\x1f", 2)
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("unexpected git output: %q", trimmed)
+	}
+	return parts[0], parts[1], nil
+}
+
+// buildAll iterates over every target and captures the results.
+func (s *Service) buildAll(ctx context.Context, commit string) []Result {
+	results := make([]Result, 0, len(s.targets))
+	for _, target := range s.targets {
+		res := s.buildTarget(ctx, commit, target)
+		results = append(results, res)
+	}
+	return results
+}
+
+// buildTarget invokes go build with the given GOOS/GOARCH values.
+func (s *Service) buildTarget(ctx context.Context, commit string, target Target) Result {
+	artifactDir := filepath.Join(s.repoPath, s.output, commit)
+	if err := os.MkdirAll(artifactDir, 0o755); err != nil {
+		return Result{Target: target, Err: err}
+	}
+	name := fmt.Sprintf("%s-%s-%s", s.binary, target.GOOS, target.GOARCH)
+	if target.GOOS == "windows" {
+		name += ".exe"
+	}
+	output := filepath.Join(artifactDir, name)
+	args := []string{"build", "-o", output, "./cmd/server"}
+	cmd := exec.CommandContext(ctx, "go", args...)
+	cmd.Dir = s.repoPath
+	cmd.Env = append(os.Environ(), "GOOS="+target.GOOS, "GOARCH="+target.GOARCH)
+	if err := cmd.Run(); err != nil {
+		return Result{Target: target, Artifact: output, Err: err}
+	}
+	return Result{Target: target, Artifact: output}
+}

--- a/internal/mail/service.go
+++ b/internal/mail/service.go
@@ -1,0 +1,225 @@
+package mail
+
+// Package mail manages outgoing messages and embeds a minimal SMTP server.
+// We keep everything asynchronous and channel-based to respect the project rules.
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+)
+
+// Message represents a simple email message body.
+type Message struct {
+	From       string
+	To         string
+	Subject    string
+	Body       string
+	ReceivedAt time.Time
+}
+
+// Service orchestrates deliveries and the SMTP listener.
+type Service struct {
+	deliveries chan Message
+	requests   chan interface{}
+	smtpConns  chan net.Conn
+	smtpCtrl   chan interface{}
+}
+
+// NewService creates a new mail service.
+func NewService(buffer int) *Service {
+	svc := &Service{
+		deliveries: make(chan Message, buffer),
+		requests:   make(chan interface{}),
+		smtpConns:  make(chan net.Conn),
+		smtpCtrl:   make(chan interface{}),
+	}
+	go svc.loop()
+	go svc.acceptLoop()
+	go svc.smtpManager()
+	return svc
+}
+
+// loop stores messages in mailboxes and handles queries.
+func (s *Service) loop() {
+	mailboxes := map[string][]Message{}
+	for {
+		select {
+		case msg := <-s.deliveries:
+			msg.ReceivedAt = time.Now().UTC()
+			key := strings.ToLower(msg.To)
+			mailboxes[key] = append(mailboxes[key], msg)
+		case req := <-s.requests:
+			switch msg := req.(type) {
+			case listMailboxRequest:
+				box := append([]Message(nil), mailboxes[strings.ToLower(msg.Address)]...)
+				msg.Resp <- box
+			}
+		}
+	}
+}
+
+// acceptLoop listens for new SMTP connections and delegates handling.
+func (s *Service) acceptLoop() {
+	for conn := range s.smtpConns {
+		go s.handleSMTP(conn)
+	}
+}
+
+type startSMTP struct {
+	Addr string
+	Resp chan error
+}
+
+type stopSMTP struct {
+	Resp chan struct{}
+}
+
+// smtpManager owns the SMTP listener lifecycle so we avoid shared state.
+func (s *Service) smtpManager() {
+	var listener net.Listener
+	var acceptDone chan struct{}
+	for msg := range s.smtpCtrl {
+		switch cmd := msg.(type) {
+		case startSMTP:
+			if listener != nil {
+				cmd.Resp <- fmt.Errorf("SMTP server already running")
+				continue
+			}
+			ln, err := net.Listen("tcp", cmd.Addr)
+			if err != nil {
+				cmd.Resp <- err
+				continue
+			}
+			listener = ln
+			acceptDone = make(chan struct{})
+			go s.acceptConnections(ln, acceptDone)
+			cmd.Resp <- nil
+		case stopSMTP:
+			if listener != nil {
+				listener.Close()
+				<-acceptDone
+				listener = nil
+				acceptDone = nil
+			}
+			close(cmd.Resp)
+		}
+	}
+}
+
+// acceptConnections hands accepted sockets to the processing loop.
+func (s *Service) acceptConnections(ln net.Listener, done chan struct{}) {
+	defer close(done)
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		s.smtpConns <- conn
+	}
+}
+
+type listMailboxRequest struct {
+	Address string
+	Resp    chan []Message
+}
+
+// Deliveries exposes the channel where other services push outgoing mail.
+func (s *Service) Deliveries() chan<- Message {
+	return s.deliveries
+}
+
+// ListMailbox returns a copy of the mailbox for a given address.
+func (s *Service) ListMailbox(address string) []Message {
+	resp := make(chan []Message)
+	s.requests <- listMailboxRequest{Address: address, Resp: resp}
+	return <-resp
+}
+
+// StartSMTPServer begins listening on the provided address.
+func (s *Service) StartSMTPServer(addr string) error {
+	resp := make(chan error, 1)
+	s.smtpCtrl <- startSMTP{Addr: addr, Resp: resp}
+	return <-resp
+}
+
+// StopSMTPServer shuts down the listener so an updater can free the port.
+func (s *Service) StopSMTPServer() {
+	done := make(chan struct{})
+	s.smtpCtrl <- stopSMTP{Resp: done}
+	<-done
+}
+
+// handleSMTP implements a very small subset of SMTP.
+func (s *Service) handleSMTP(conn net.Conn) {
+	defer conn.Close()
+	writer := bufio.NewWriter(conn)
+	reader := bufio.NewReader(conn)
+	fmt.Fprintln(writer, "220 chicha-care SMTP ready")
+	writer.Flush()
+	var from string
+	recipients := []string{}
+	var data bytes.Buffer
+	inData := false
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return
+		}
+		line = strings.TrimSpace(line)
+		if !inData {
+			switch {
+			case strings.HasPrefix(strings.ToUpper(line), "HELO") || strings.HasPrefix(strings.ToUpper(line), "EHLO"):
+				fmt.Fprintln(writer, "250 Hello")
+			case strings.HasPrefix(strings.ToUpper(line), "MAIL FROM:"):
+				from = strings.Trim(strings.TrimPrefix(line, "MAIL FROM:"), "<>")
+				fmt.Fprintln(writer, "250 Sender OK")
+			case strings.HasPrefix(strings.ToUpper(line), "RCPT TO:"):
+				rcpt := strings.Trim(strings.TrimPrefix(line, "RCPT TO:"), "<>")
+				recipients = append(recipients, rcpt)
+				fmt.Fprintln(writer, "250 Recipient OK")
+			case strings.EqualFold(line, "DATA"):
+				inData = true
+				data.Reset()
+				fmt.Fprintln(writer, "354 End data with <CR><LF>.<CR><LF>")
+			case strings.EqualFold(line, "QUIT"):
+				fmt.Fprintln(writer, "221 Bye")
+				writer.Flush()
+				return
+			default:
+				fmt.Fprintln(writer, "250 OK")
+			}
+			writer.Flush()
+		} else {
+			if line == "." {
+				for _, rcpt := range recipients {
+					s.deliveries <- Message{From: from, To: rcpt, Subject: "Received via SMTP", Body: data.String()}
+				}
+				fmt.Fprintln(writer, "250 Message accepted")
+				writer.Flush()
+				inData = false
+				recipients = nil
+			} else {
+				data.WriteString(line)
+				data.WriteByte('\n')
+			}
+		}
+	}
+}
+
+// Enqueue pushes an outbound message without blocking callers.
+func (s *Service) Enqueue(msg Message) {
+	select {
+	case s.deliveries <- msg:
+	default:
+		// We drop the message to keep the system responsive under load.
+	}
+}
+
+// EnqueueSMTPConnection lets tests inject fake SMTP connections.
+func (s *Service) EnqueueSMTPConnection(conn net.Conn) {
+	s.smtpConns <- conn
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -1,0 +1,74 @@
+package scheduler
+
+// Package scheduler periodically triggers invoice generation.
+// We rely on goroutines, channels and select statements for coordination.
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/example/chicha-care/internal/billing"
+)
+
+// Scheduler owns the ticker that drives invoice runs.
+type Scheduler struct {
+	billing  *billing.Service
+	interval time.Duration
+	amount   float64
+	stop     chan struct{}
+	done     chan struct{}
+}
+
+// New creates a scheduler with the provided billing service and interval.
+func New(bill *billing.Service, interval time.Duration, amount float64) *Scheduler {
+	return &Scheduler{
+		billing:  bill,
+		interval: interval,
+		amount:   amount,
+		stop:     make(chan struct{}),
+		done:     make(chan struct{}),
+	}
+}
+
+// Start launches the scheduler loop.
+func (s *Scheduler) Start() {
+	go s.loop()
+}
+
+// loop waits on the ticker and stop channels.
+func (s *Scheduler) loop() {
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			s.runCycle()
+		case <-s.stop:
+			close(s.done)
+			return
+		}
+	}
+}
+
+// runCycle fetches clients and produces invoices for each of them.
+func (s *Scheduler) runCycle() {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	clients, err := s.billing.ListClients(ctx)
+	if err != nil {
+		log.Printf("scheduler: list clients failed: %v", err)
+		return
+	}
+	for _, client := range clients {
+		if _, err := s.billing.CreateInvoice(ctx, client.ID, s.amount); err != nil {
+			log.Printf("scheduler: invoice for %s failed: %v", client.ID, err)
+		}
+	}
+}
+
+// Stop asks the scheduler loop to halt and waits for confirmation.
+func (s *Scheduler) Stop() {
+	close(s.stop)
+	<-s.done
+}

--- a/internal/storage/driver.go
+++ b/internal/storage/driver.go
@@ -1,0 +1,397 @@
+package storage
+
+// This package implements a very small SQL driver that keeps data in memory.
+// We only rely on the standard library and we expose the driver through the
+// database/sql package to respect the project constraints.
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Register exposes the in-memory driver so other packages can open a database
+// connection using database/sql without depending on external components.
+func Register() {
+	// We register the driver only once and ignore the error if registration
+	// happens multiple times because database/sql panics in that case.
+	sql.Register("inmemory", Driver{})
+}
+
+// Driver implements the database/sql/driver.Driver interface.
+type Driver struct{}
+
+// Open connects to the in-memory manager that keeps all application data.
+func (Driver) Open(name string) (driver.Conn, error) {
+	mgr := getManager(name)
+	return &conn{mgr: mgr}, nil
+}
+
+// conn is a lightweight handle for a logical connection to the in-memory store.
+type conn struct {
+	mgr *manager
+}
+
+// Prepare stores the SQL query so Exec and Query can send commands to the manager.
+func (c *conn) Prepare(query string) (driver.Stmt, error) {
+	return &stmt{mgr: c.mgr, query: query}, nil
+}
+
+// Close does not need to release anything because the manager is shared globally.
+func (c *conn) Close() error { return nil }
+
+// Begin is not implemented because we do not support SQL transactions.
+func (c *conn) Begin() (driver.Tx, error) {
+	return nil, errors.New("transactions not supported")
+}
+
+// stmt delegates Exec and Query to the manager.
+type stmt struct {
+	mgr   *manager
+	query string
+}
+
+// Close is a no-op for prepared statements in this in-memory implementation.
+func (s *stmt) Close() error { return nil }
+
+// NumInput returns -1 so database/sql will not try to validate argument counts.
+func (s *stmt) NumInput() int { return -1 }
+
+// Exec sends a command that modifies state.
+func (s *stmt) Exec(args []driver.Value) (driver.Result, error) {
+	req := execRequest{query: s.query, args: args, resp: make(chan execResponse)}
+	s.mgr.execs <- req
+	res := <-req.resp
+	return res.result, res.err
+}
+
+// Query sends a command that returns rows.
+func (s *stmt) Query(args []driver.Value) (driver.Rows, error) {
+	req := queryRequest{query: s.query, args: args, resp: make(chan queryResponse)}
+	s.mgr.queries <- req
+	res := <-req.resp
+	if res.err != nil {
+		return nil, res.err
+	}
+	return &rows{columns: res.columns, data: res.data}, nil
+}
+
+// execRequest represents a state-changing command.
+type execRequest struct {
+	query string
+	args  []driver.Value
+	resp  chan execResponse
+}
+
+type execResponse struct {
+	result driver.Result
+	err    error
+}
+
+// queryRequest represents a read-only command.
+type queryRequest struct {
+	query string
+	args  []driver.Value
+	resp  chan queryResponse
+}
+
+type queryResponse struct {
+	columns []string
+	data    [][]driver.Value
+	err     error
+}
+
+// rows implements the driver.Rows interface so database/sql can iterate.
+type rows struct {
+	columns []string
+	data    [][]driver.Value
+	idx     int
+}
+
+// Columns returns the names of the columns for the current result set.
+func (r *rows) Columns() []string { return r.columns }
+
+// Close releases the row iterator.
+func (r *rows) Close() error {
+	r.data = nil
+	return nil
+}
+
+// Next streams one row at a time using channels-friendly semantics.
+func (r *rows) Next(dest []driver.Value) error {
+	if r.idx >= len(r.data) {
+		return io.EOF
+	}
+	copy(dest, r.data[r.idx])
+	r.idx++
+	return nil
+}
+
+// manager serializes access to the maps that store records.
+type manager struct {
+	execs   chan execRequest
+	queries chan queryRequest
+}
+
+type clientRecord struct {
+	ID    string
+	Name  string
+	Email string
+}
+
+type invoiceRecord struct {
+	ID        string
+	ClientID  string
+	Amount    float64
+	IssuedAt  time.Time
+	Document  []byte
+	Signature []byte
+}
+
+type userRecord struct {
+	Username string
+	Hash     string
+}
+
+// managerLoop owns the data and therefore does not require mutexes.
+func managerLoop() {
+	state := make(map[string]*store)
+	for {
+		select {
+		case req := <-registryChan:
+			st, ok := state[req.name]
+			if !ok {
+				st = newStore()
+				state[req.name] = st
+			}
+			req.resp <- st.mgr
+		}
+	}
+}
+
+type store struct {
+	mgr      *manager
+	clients  map[string]clientRecord
+	invoices map[string]invoiceRecord
+	users    map[string]userRecord
+}
+
+func newStore() *store {
+	mgr := &manager{
+		execs:   make(chan execRequest),
+		queries: make(chan queryRequest),
+	}
+	st := &store{
+		mgr:      mgr,
+		clients:  make(map[string]clientRecord),
+		invoices: make(map[string]invoiceRecord),
+		users:    make(map[string]userRecord),
+	}
+	go st.run()
+	return st
+}
+
+// run handles all commands sequentially so the data remains consistent.
+func (s *store) run() {
+	for {
+		select {
+		case execReq := <-s.mgr.execs:
+			execReq.resp <- execResponse{result: driver.RowsAffected(0), err: s.handleExec(execReq.query, execReq.args)}
+		case queryReq := <-s.mgr.queries:
+			cols, data, err := s.handleQuery(queryReq.query, queryReq.args)
+			queryReq.resp <- queryResponse{columns: cols, data: data, err: err}
+		}
+	}
+}
+
+// handleExec parses supported SQL statements.
+func (s *store) handleExec(query string, args []driver.Value) error {
+	normalized := strings.ToLower(strings.TrimSpace(query))
+	switch {
+	case strings.HasPrefix(normalized, "create table"):
+		// Table creation is a no-op because the in-memory maps are already set.
+		return nil
+	case strings.HasPrefix(normalized, "insert into clients"):
+		if len(args) < 3 {
+			return errors.New("invalid client insert")
+		}
+		id := toString(args[0])
+		if _, exists := s.clients[id]; exists {
+			return fmt.Errorf("client %s already exists", id)
+		}
+		s.clients[id] = clientRecord{ID: id, Name: toString(args[1]), Email: toString(args[2])}
+		return nil
+	case strings.HasPrefix(normalized, "insert into invoices"):
+		if len(args) < 6 {
+			return errors.New("invalid invoice insert")
+		}
+		amt, err := toFloat(args[2])
+		if err != nil {
+			return err
+		}
+		issued, err := toTime(args[3])
+		if err != nil {
+			return err
+		}
+		id := toString(args[0])
+		if _, exists := s.invoices[id]; exists {
+			return fmt.Errorf("invoice %s already exists", id)
+		}
+		s.invoices[id] = invoiceRecord{
+			ID:        id,
+			ClientID:  toString(args[1]),
+			Amount:    amt,
+			IssuedAt:  issued,
+			Document:  toBytes(args[4]),
+			Signature: toBytes(args[5]),
+		}
+		return nil
+	case strings.HasPrefix(normalized, "insert into users"):
+		if len(args) < 2 {
+			return errors.New("invalid user insert")
+		}
+		username := toString(args[0])
+		if _, exists := s.users[username]; exists {
+			return fmt.Errorf("user %s already exists", username)
+		}
+		s.users[username] = userRecord{Username: username, Hash: toString(args[1])}
+		return nil
+	default:
+		return fmt.Errorf("unsupported exec query: %s", query)
+	}
+}
+
+// handleQuery reads data from the in-memory store.
+func (s *store) handleQuery(query string, args []driver.Value) ([]string, [][]driver.Value, error) {
+	normalized := strings.ToLower(strings.TrimSpace(query))
+	switch {
+	case strings.HasPrefix(normalized, "select id,name,email from clients where id"):
+		if len(args) < 1 {
+			return nil, nil, errors.New("missing client id")
+		}
+		id := toString(args[0])
+		rec, ok := s.clients[id]
+		if !ok {
+			return []string{"id", "name", "email"}, nil, nil
+		}
+		return []string{"id", "name", "email"}, [][]driver.Value{{rec.ID, rec.Name, rec.Email}}, nil
+	case strings.HasPrefix(normalized, "select id,name,email from clients"):
+		rows := make([][]driver.Value, 0, len(s.clients))
+		for _, rec := range s.clients {
+			rows = append(rows, []driver.Value{rec.ID, rec.Name, rec.Email})
+		}
+		return []string{"id", "name", "email"}, rows, nil
+	case strings.HasPrefix(normalized, "select id,client_id,amount,issued_at,document,signature from invoices where client_id"):
+		if len(args) < 1 {
+			return nil, nil, errors.New("missing client id")
+		}
+		clientID := toString(args[0])
+		rows := [][]driver.Value{}
+		for _, rec := range s.invoices {
+			if rec.ClientID == clientID {
+				rows = append(rows, []driver.Value{rec.ID, rec.ClientID, rec.Amount, rec.IssuedAt, rec.Document, rec.Signature})
+			}
+		}
+		return []string{"id", "client_id", "amount", "issued_at", "document", "signature"}, rows, nil
+	case strings.HasPrefix(normalized, "select id,client_id,amount,issued_at,document,signature from invoices"):
+		rows := make([][]driver.Value, 0, len(s.invoices))
+		for _, rec := range s.invoices {
+			rows = append(rows, []driver.Value{rec.ID, rec.ClientID, rec.Amount, rec.IssuedAt, rec.Document, rec.Signature})
+		}
+		return []string{"id", "client_id", "amount", "issued_at", "document", "signature"}, rows, nil
+	case strings.HasPrefix(normalized, "select username,hash from users where username"):
+		if len(args) < 1 {
+			return nil, nil, errors.New("missing username")
+		}
+		username := toString(args[0])
+		rec, ok := s.users[username]
+		if !ok {
+			return []string{"username", "hash"}, nil, nil
+		}
+		return []string{"username", "hash"}, [][]driver.Value{{rec.Username, rec.Hash}}, nil
+	default:
+		return nil, nil, fmt.Errorf("unsupported query: %s", query)
+	}
+}
+
+// Helper conversion utilities keep the code tidy and readable.
+func toString(v driver.Value) string {
+	switch val := v.(type) {
+	case string:
+		return val
+	case []byte:
+		return string(val)
+	default:
+		return fmt.Sprint(val)
+	}
+}
+
+func toFloat(v driver.Value) (float64, error) {
+	switch val := v.(type) {
+	case float64:
+		return val, nil
+	case string:
+		return strconv.ParseFloat(val, 64)
+	case []byte:
+		return strconv.ParseFloat(string(val), 64)
+	default:
+		return 0, fmt.Errorf("cannot convert %T to float64", v)
+	}
+}
+
+func toTime(v driver.Value) (time.Time, error) {
+	switch val := v.(type) {
+	case time.Time:
+		return val, nil
+	case string:
+		parsed, err := time.Parse(time.RFC3339Nano, val)
+		if err != nil {
+			return time.Time{}, err
+		}
+		return parsed, nil
+	case []byte:
+		parsed, err := time.Parse(time.RFC3339Nano, string(val))
+		if err != nil {
+			return time.Time{}, err
+		}
+		return parsed, nil
+	default:
+		return time.Time{}, fmt.Errorf("cannot convert %T to time.Time", v)
+	}
+}
+
+func toBytes(v driver.Value) []byte {
+	switch val := v.(type) {
+	case []byte:
+		return val
+	case string:
+		return []byte(val)
+	default:
+		return []byte(fmt.Sprint(val))
+	}
+}
+
+// The registry coordinates managers for multiple logical databases.
+
+type registryRequest struct {
+	name string
+	resp chan *manager
+}
+
+var registryChan = make(chan registryRequest)
+
+func init() {
+	go managerLoop()
+}
+
+// getManager returns the manager for the provided database name.
+func getManager(name string) *manager {
+	req := registryRequest{name: name, resp: make(chan *manager)}
+	registryChan <- req
+	return <-req.resp
+}

--- a/internal/update/service.go
+++ b/internal/update/service.go
@@ -1,0 +1,243 @@
+package update
+
+// Package update polls GitHub releases to drive self-updates.
+// We rely on channels to notify the rest of the system about new binaries.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// Config configures the Service with repository and timing details.
+type Config struct {
+	Owner          string
+	Repo           string
+	Binary         string
+	Interval       time.Duration
+	CurrentVersion string
+	BaseURL        string
+	Client         *http.Client
+}
+
+// Event describes an available update payload ready for installation.
+type Event struct {
+	Version    string
+	BinaryPath string
+}
+
+// Service periodically queries GitHub for new releases.
+type Service struct {
+	cfg     Config
+	events  chan Event
+	stop    chan struct{}
+	done    chan struct{}
+	client  *http.Client
+	lastTag string
+}
+
+// NewService builds a Service with defaults aligned to our needs.
+func NewService(cfg Config) *Service {
+	if cfg.Interval == 0 {
+		cfg.Interval = time.Minute
+	}
+	if cfg.Binary == "" {
+		cfg.Binary = "chicha-care"
+	}
+	if cfg.BaseURL == "" {
+		cfg.BaseURL = "https://api.github.com"
+	}
+	client := cfg.Client
+	if client == nil {
+		client = &http.Client{Timeout: 20 * time.Second}
+	}
+	return &Service{
+		cfg:    cfg,
+		events: make(chan Event, 1),
+		stop:   make(chan struct{}),
+		done:   make(chan struct{}),
+		client: client,
+	}
+}
+
+// Events exposes the notifications channel.
+func (s *Service) Events() <-chan Event {
+	return s.events
+}
+
+// Start launches the polling loop.
+func (s *Service) Start() {
+	go s.loop()
+}
+
+// Stop stops the polling loop and closes the events channel.
+func (s *Service) Stop() {
+	close(s.stop)
+	<-s.done
+}
+
+// loop performs the periodic release lookups.
+func (s *Service) loop() {
+	defer close(s.done)
+	ticker := time.NewTicker(s.cfg.Interval)
+	defer ticker.Stop()
+	s.checkOnce()
+	for {
+		select {
+		case <-ticker.C:
+			s.checkOnce()
+		case <-s.stop:
+			close(s.events)
+			return
+		}
+	}
+}
+
+// checkOnce fetches the latest release and downloads the asset if new.
+func (s *Service) checkOnce() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	release, err := s.fetchLatest(ctx)
+	if err != nil {
+		// We keep the log local to avoid spamming event consumers with noise.
+		fmt.Fprintf(os.Stderr, "update check failed: %v\n", err)
+		return
+	}
+	if release.Tag == "" || release.Tag == s.cfg.CurrentVersion || release.Tag == s.lastTag {
+		return
+	}
+	assetURL, assetName := release.AssetFor(runtime.GOOS, runtime.GOARCH, s.cfg.Binary)
+	if assetURL == "" {
+		fmt.Fprintf(os.Stderr, "update: no asset for %s/%s in release %s\n", runtime.GOOS, runtime.GOARCH, release.Tag)
+		return
+	}
+	path, err := s.download(ctx, assetURL, assetName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "update download failed: %v\n", err)
+		return
+	}
+	s.lastTag = release.Tag
+	s.events <- Event{Version: release.Tag, BinaryPath: path}
+}
+
+// releaseInfo captures the small subset of GitHub release payload we care about.
+type releaseInfo struct {
+	Tag    string
+	Assets []struct {
+		Name string `json:"name"`
+		URL  string `json:"browser_download_url"`
+	} `json:"assets"`
+}
+
+// AssetFor returns the asset URL matching the OS/Arch combination.
+func (r releaseInfo) AssetFor(goos, goarch, binary string) (string, string) {
+	base := fmt.Sprintf("%s-%s-%s", binary, goos, goarch)
+	targets := []string{base, base + ".exe"}
+	for _, asset := range r.Assets {
+		for _, candidate := range targets {
+			if strings.EqualFold(asset.Name, candidate) {
+				return asset.URL, asset.Name
+			}
+		}
+	}
+	return "", ""
+}
+
+// fetchLatest queries the GitHub releases API.
+func (s *Service) fetchLatest(ctx context.Context) (releaseInfo, error) {
+	if s.cfg.Owner == "" || s.cfg.Repo == "" {
+		return releaseInfo{}, errors.New("update service requires owner and repo")
+	}
+	url := fmt.Sprintf("%s/repos/%s/%s/releases/latest", strings.TrimRight(s.cfg.BaseURL, "/"), s.cfg.Owner, s.cfg.Repo)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return releaseInfo{}, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "chicha-care-updater")
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return releaseInfo{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return releaseInfo{}, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+	var payload struct {
+		TagName string         `json:"tag_name"`
+		Assets  []releaseAsset `json:"assets"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return releaseInfo{}, err
+	}
+	assets := make([]struct {
+		Name string `json:"name"`
+		URL  string `json:"browser_download_url"`
+	}, 0, len(payload.Assets))
+	for _, a := range payload.Assets {
+		assets = append(assets, struct {
+			Name string `json:"name"`
+			URL  string `json:"browser_download_url"`
+		}{Name: a.Name, URL: a.URL})
+	}
+	return releaseInfo{Tag: payload.TagName, Assets: assets}, nil
+}
+
+type releaseAsset struct {
+	Name string `json:"name"`
+	URL  string `json:"browser_download_url"`
+}
+
+// download retrieves the binary and places it near the current executable.
+func (s *Service) download(ctx context.Context, url, name string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("User-Agent", "chicha-care-updater")
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return "", fmt.Errorf("download status %d: %s", resp.StatusCode, string(body))
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Dir(exe)
+	path := filepath.Join(dir, name)
+	tmp, err := os.CreateTemp(dir, name+".part")
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		tmp.Close()
+		os.Remove(tmp.Name())
+	}()
+	if _, err := io.Copy(tmp, resp.Body); err != nil {
+		return "", err
+	}
+	if err := tmp.Chmod(0o755); err != nil {
+		return "", err
+	}
+	if err := tmp.Close(); err != nil {
+		return "", err
+	}
+	if err := os.Rename(tmp.Name(), path); err != nil {
+		return "", err
+	}
+	return path, nil
+}

--- a/internal/upgrade/handshake.go
+++ b/internal/upgrade/handshake.go
@@ -1,0 +1,88 @@
+package upgrade
+
+// Package upgrade defines the small file-based handshake shared by old and new binaries.
+// We prefer this lightweight channel over sockets so the flow works everywhere.
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"time"
+)
+
+// State constants written to the coordination file.
+const (
+	StatePending = "pending"
+	StateStandby = "standby"
+	StateGo      = "go"
+	StateRunning = "running"
+	StateAbort   = "abort"
+)
+
+// ErrAborted indicates that the upgrade should be cancelled.
+var ErrAborted = errors.New("upgrade aborted")
+
+// WriteState overwrites the file with the provided marker.
+func WriteState(path, state string) error {
+	return os.WriteFile(path, []byte(state), 0o600)
+}
+
+// ReadState loads the current marker from disk.
+func ReadState(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+// WaitForGo is called by the new process: announce standby then wait for go.
+func WaitForGo(ctx context.Context, path string) error {
+	if err := WriteState(path, StateStandby); err != nil {
+		return err
+	}
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			state, err := ReadState(path)
+			if err != nil {
+				continue
+			}
+			switch state {
+			case StateGo:
+				return nil
+			case StateAbort:
+				return ErrAborted
+			}
+		}
+	}
+}
+
+// WaitForState waits until the file matches one of the expected states.
+func WaitForState(ctx context.Context, path string, states ...string) (string, error) {
+	wanted := map[string]struct{}{}
+	for _, state := range states {
+		wanted[state] = struct{}{}
+	}
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-ticker.C:
+			state, err := ReadState(path)
+			if err != nil {
+				continue
+			}
+			if _, ok := wanted[state]; ok {
+				return state, nil
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a build service that watches for "Stable Release" commits and produces cross-platform binaries
- integrate a GitHub release polling updater with file-based handshakes and rollback-aware handover logic
- extend the server bootstrap to coordinate builds, updates, and graceful restarts while allowing the SMTP listener to stop and restart via channels

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d3e052cfa483329f8962115c3beb4c